### PR TITLE
Adds test and updated method for zero quantity.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -65,10 +65,10 @@ const formatCheckoutCart = checkoutData => {
 const updateQuantity = (quantity, skuID, skus) => {
   quantity = isNaN(quantity) ? 0 : quantity;
 
-  return {
-    ...skus,
-    [skuID]: quantity,
-  };
+  const updatedSkus = skus;
+  quantity === 0 ? delete updatedSkus[skuID] : updatedSkus[skuID] = quantity
+
+  return updatedSkus
 };
 
 const removeSku = (skuID, skus) => {

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -118,4 +118,16 @@ describe('useStripeCart', () => {
 
     expect(result.current.skus).toEqual({});
   });
+
+  it('handleQuantityChange removes item from skus object when quantity reaches 0', () => {
+    const wrapper = createWrapper();
+    const { result } = renderHook(() => useStripeCart(), { wrapper });
+
+    act(() => {
+      result.current.addItem(mockSku)
+      result.current.handleQuantityChange(0, mockSku.sku)
+    })
+
+    expect(result.current.skus).toEqual({})
+  })
 });


### PR DESCRIPTION
This test and refactor may be unnecessary if we move to a single source of truth for the SKUs coming from cartItems but this is how'd I'd see the current implementation being fixed.

The updateQuantity passes back an object without the key/value pair of the zeroed SKU now.