### PR TITLE
Add tests for calculation of totalPrice

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -23,38 +23,22 @@ const checkoutCart = (skus, { sku }, quantity = 1) => {
   }
 };
 
-const formatDetailedCart = cartItems => {
-  const details = cartItems.reduce((acc, current) => {
-    if (acc.hasOwnProperty(current.sku)) {
-      acc = {
-        ...acc,
-        [current.sku]: {
-          ...current,
-          price: acc[current.sku].price + current.price,
-          formattedPrice: toCurrency({
-            price: acc[current.sku].price + current.price,
-            currency: current.currency,
-          }),
-          quantity: acc[current.sku].quantity + 1,
-        },
-      };
-    } else {
-      acc = {
-        ...acc,
-        [current.sku]: {
-          ...current,
-          quantity: 1,
-          formattedPrice: toCurrency({
-            price: current.price,
-            currency: current.currency,
-          }),
-        },
-      };
-    }
-    return acc;
-  }, {});
+const formatDetailedCart = (currency, cartItems) => {
+  return cartItems.reduce((acc, current) => {
+    const quantity = (acc[current.sku]?.quantity ?? 0) + 1;
+    const price = (acc[current.sku]?.price ?? 0) + current.price;
+    const formattedPrice = toCurrency({ price, currency });
 
-  return details;
+    return {
+      ...acc,
+      [current.sku]: {
+        ...current,
+        quantity,
+        price,
+        formattedPrice,
+      },
+    };
+  }, {});
 };
 
 const formatCheckoutCart = checkoutData => {
@@ -228,7 +212,7 @@ export const useStripeCart = () => {
   typeof localStorage === 'object' &&
     localStorage.setItem('skus', JSON.stringify(storageReference));
 
-  const cartDetails = formatDetailedCart(cartItems);
+  const cartDetails = formatDetailedCart(currency, cartItems);
 
   const cartCount = checkoutData.reduce(
     (acc, current) => acc + current.quantity,

--- a/src/index.js
+++ b/src/index.js
@@ -173,6 +173,7 @@ export const CartProvider = ({
   billingAddressCollection,
   successUrl,
   cancelUrl,
+  currency,
 }) => {
   const skuStorage =
     typeof window !== 'undefined'
@@ -189,6 +190,7 @@ export const CartProvider = ({
         billingAddressCollection,
         successUrl,
         cancelUrl,
+        currency,
       })}
     >
       {children}
@@ -208,6 +210,7 @@ export const useStripeCart = () => {
     billingAddressCollection,
     successUrl,
     cancelUrl,
+    currency,
   } = cart;
 
   let storageReference =
@@ -220,7 +223,7 @@ export const useStripeCart = () => {
 
   const checkoutData = formatCheckoutCart(skus);
   
-  const totalPrice = () => calculateTotalPrice('usd', cartItems);
+  const totalPrice = () => calculateTotalPrice(currency, cartItems);
 
   typeof localStorage === 'object' &&
     localStorage.setItem('skus', JSON.stringify(storageReference));

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 import React, { createContext, useReducer, useContext } from 'react';
-import { toCurrency } from './util';
+import { toCurrency, calculateTotalPrice } from './util';
 
 /**
  * @function checkoutCart
@@ -219,19 +219,8 @@ export const useStripeCart = () => {
   }
 
   const checkoutData = formatCheckoutCart(skus);
-
-  const totalPrice = () => {
-    let total = 0;
-    let currency = 'usd';
-    const totalPrice = cartItems.reduce((acc, current) => {
-      currency = current.currency;
-      return acc + current.price;
-    }, 0);
-
-    total = totalPrice;
-
-    return toCurrency({ price: total, currency: currency });
-  };
+  
+  const totalPrice = () => calculateTotalPrice('usd', cartItems);
 
   typeof localStorage === 'object' &&
     localStorage.setItem('skus', JSON.stringify(storageReference));

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -64,9 +64,10 @@ const createWrapper = () => ({ children }) => {
   return (
     <CartProvider
       billingAddressCollection={false}
-      successUrl={'https://egghead.io'}
-      cancelUrl={'https://egghead.io'}
+      successUrl="https://egghead.io"
+      cancelUrl="https://egghead.io"
       stripe={stripeMock}
+      currency="USD"
     >
       {children}
     </CartProvider>

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -29,13 +29,13 @@ const mockSku3 = {
   sku: 'sku_abc234',
   price: 100,
   image: 'https://www.fillmurray.com/300/300',
-  currency: 'usd',
+  currency: 'USD',
 };
 const mockSku2 = {
   sku: 'sku_xyz456',
   price: 300,
   image: 'https://www.fillmurray.com/300/300',
-  currency: 'gbp',
+  currency: 'USD',
 };
 
 const mockDetailedSku = {
@@ -55,7 +55,7 @@ const mockDetailedSku2 = {
     quantity: 1,
     currency: mockSku2.currency,
     price: mockSku2.price,
-    formattedPrice: '£3.00',
+    formattedPrice: '$3.00',
     image: mockSku2.image,
   },
 };

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -73,18 +73,19 @@ const createWrapper = () => ({ children }) => {
   );
 };
 
+
+let result;
+beforeEach(() => {
+  const wrapper = createWrapper();
+  result = renderHook(() => useStripeCart(), { wrapper }).result;
+});
+
 describe('useStripeCart', () => {
   it('renderps', () => {
-    const wrapper = createWrapper();
-    const { result } = renderHook(() => useStripeCart(), { wrapper });
-
     expect(result.current.cartItems).toEqual(INITIAL_STATE.cartItems);
   });
 
   it('addItems adds items to cart', () => {
-    const wrapper = createWrapper();
-    const { result } = renderHook(() => useStripeCart(), { wrapper });
-
     act(() => {
       result.current.addItem(mockSku);
     });
@@ -93,9 +94,6 @@ describe('useStripeCart', () => {
   });
 
   it('cartCount increments when addItem is executed', () => {
-    const wrapper = createWrapper();
-    const { result } = renderHook(() => useStripeCart(), { wrapper });
-
     expect(result.current.cartCount).toBe(0);
 
     act(() => {
@@ -106,9 +104,6 @@ describe('useStripeCart', () => {
   });
 
   it('skus object updates with sku id and quantity based on addItems', () => {
-    const wrapper = createWrapper();
-    const { result } = renderHook(() => useStripeCart(), { wrapper });
-
     expect(result.current.skus).toEqual({});
 
     act(() => {
@@ -121,9 +116,6 @@ describe('useStripeCart', () => {
   });
 
   it('checkoutData builds an array of objects to prepare for redirectToCheckout', () => {
-    const wrapper = createWrapper();
-    const { result } = renderHook(() => useStripeCart(), { wrapper });
-
     expect(result.current.checkoutData).toEqual([]);
 
     act(() => {
@@ -136,9 +128,6 @@ describe('useStripeCart', () => {
   });
 
   it('deleteItem removes item from sku object', () => {
-    const wrapper = createWrapper();
-    const { result } = renderHook(() => useStripeCart(), { wrapper });
-
     act(() => {
       result.current.addItem(mockSku);
     });
@@ -155,9 +144,6 @@ describe('useStripeCart', () => {
   });
 
   it('deleteItem remove the correct item from the cart', () => {
-    const wrapper = createWrapper();
-    const { result } = renderHook(() => useStripeCart(), { wrapper });
-
     act(() => {
       result.current.addItem(mockSku);
       result.current.addItem(mockSku2);
@@ -178,9 +164,6 @@ describe('useStripeCart', () => {
   });
 
   it('should update totalPrice', () => {
-    const wrapper = createWrapper();
-    const { result } = renderHook(() => useStripeCart(), { wrapper });
-
     act(() => {
       result.current.addItem(mockSku);
     });
@@ -189,9 +172,6 @@ describe('useStripeCart', () => {
   });
 
   it('should update totalPrice when two items are added', () => {
-    const wrapper = createWrapper();
-    const { result } = renderHook(() => useStripeCart(), { wrapper });
-
     act(() => {
       result.current.addItem(mockSku);
       result.current.addItem(mockSku3);
@@ -201,9 +181,6 @@ describe('useStripeCart', () => {
   });
 
   it('storeLastClicked stores the correct value', () => {
-    const wrapper = createWrapper();
-    const { result } = renderHook(() => useStripeCart(), { wrapper });
-
     act(() => {
       result.current.storeLastClicked(mockSku.sku);
     });
@@ -212,9 +189,6 @@ describe('useStripeCart', () => {
   });
 
   it('handleQuantityChange changes the quantity correctly', () => {
-    const wrapper = createWrapper();
-    const { result } = renderHook(() => useStripeCart(), { wrapper });
-
     act(() => {
       result.current.addItem(mockSku);
       result.current.handleQuantityChange(10, mockSku.sku);
@@ -227,9 +201,6 @@ describe('useStripeCart', () => {
   });
 
   it('handleQuantityChange removes item from skus object when quantity reaches 0', () => {
-    const wrapper = createWrapper();
-    const { result } = renderHook(() => useStripeCart(), { wrapper });
-
     act(() => {
       result.current.addItem(mockSku);
       result.current.handleQuantityChange(0, mockSku.sku);
@@ -239,16 +210,11 @@ describe('useStripeCart', () => {
   });
 
   it('shouldDisplayCart should be false initially', () => {
-    const wrapper = createWrapper();
-    const { result } = renderHook(() => useStripeCart(), { wrapper });
-
+        
     expect(result.current.shouldDisplayCart).toBe(false);
   });
 
   it('shouldDisplayCart should be true after handleCartClick', () => {
-    const wrapper = createWrapper();
-    const { result } = renderHook(() => useStripeCart(), { wrapper });
-
     act(() => {
       result.current.handleCartClick();
     });
@@ -257,9 +223,6 @@ describe('useStripeCart', () => {
   });
 
   it('shouldDisplayCart should be false after 2 handleCartClick', () => {
-    const wrapper = createWrapper();
-    const { result } = renderHook(() => useStripeCart(), { wrapper });
-
     act(() => {
       result.current.handleCartClick();
       result.current.handleCartClick();
@@ -269,9 +232,6 @@ describe('useStripeCart', () => {
   });
 
   it('cartDetails should add give back a more detailed version of what skus gives back', () => {
-    const wrapper = createWrapper();
-    const { result } = renderHook(() => useStripeCart(), { wrapper });
-
     act(() => {
       result.current.addItem(mockSku);
     });
@@ -280,9 +240,6 @@ describe('useStripeCart', () => {
   });
 
   it('cartDetails will increase quantitave values when same item is added to cart', () => {
-    const wrapper = createWrapper();
-    const { result } = renderHook(() => useStripeCart(), { wrapper });
-
     act(() => {
       result.current.addItem(mockSku);
     });
@@ -306,9 +263,6 @@ describe('useStripeCart', () => {
   });
 
   it('cartDetails can add 2 skus', () => {
-    const wrapper = createWrapper();
-    const { result } = renderHook(() => useStripeCart(), { wrapper });
-
     act(() => {
       result.current.addItem(mockSku);
       result.current.addItem(mockSku2);
@@ -321,9 +275,6 @@ describe('useStripeCart', () => {
   });
 
   it('cartItems gets items removed when deleteItem is ran', () => {
-    const wrapper = createWrapper();
-    const { result } = renderHook(() => useStripeCart(), { wrapper });
-
     act(() => {
       result.current.addItem(mockSku);
     });
@@ -338,9 +289,6 @@ describe('useStripeCart', () => {
   });
 
   it('cartItems gets one item removed when deleteItem is ran', () => {
-    const wrapper = createWrapper();
-    const { result } = renderHook(() => useStripeCart(), { wrapper });
-
     act(() => {
       result.current.addItem(mockSku);
       result.current.addItem(mockSku2);

--- a/src/util.js
+++ b/src/util.js
@@ -9,7 +9,10 @@ export const toCurrency = ({ price, currency }) => {
 
 export const calculateTotalPrice = (currency, cartItems) => {
   const price = cartItems.reduce((acc, cartItem) => {
-    currency = cartItem.currency;
+    if (cartItem.currency) {
+      currency = cartItem.currency;
+    }
+
     return acc + cartItem.price;
   }, 0);
 

--- a/src/util.js
+++ b/src/util.js
@@ -8,13 +8,6 @@ export const toCurrency = ({ price, currency }) => {
 };
 
 export const calculateTotalPrice = (currency, cartItems) => {
-  const price = cartItems.reduce((acc, cartItem) => {
-    if (cartItem.currency) {
-      currency = cartItem.currency;
-    }
-
-    return acc + cartItem.price;
-  }, 0);
-
+  const price = cartItems.reduce((acc, { price }) => acc + price, 0);
   return toCurrency({ price, currency });
-}
+};

--- a/src/util.js
+++ b/src/util.js
@@ -6,3 +6,12 @@ export const toCurrency = ({ price, currency }) => {
 
   return formatted;
 };
+
+export const calculateTotalPrice = (currency, cartItems) => {
+  const price = cartItems.reduce((acc, cartItem) => {
+    currency = cartItem.currency;
+    return acc + cartItem.price;
+  }, 0);
+
+  return toCurrency({ price, currency });
+}

--- a/src/util.test.js
+++ b/src/util.test.js
@@ -12,13 +12,13 @@ describe('calculateTotalPrice', () => {
   
   it('handles cents', () => {
     const cartItemsWithDollarsAndCents = [
-      { price: 23, currency: 'USD' },
-      { price: 345, currency: 'USD' }
+      { price: 23 },
+      { price: 345 }
     ];
     
     const cartItemsWithOnlyCents = [
-      { price: 1, currency: 'USD' },
-      { price: 2, currency: 'USD' }
+      { price: 1 },
+      { price: 2 }
     ];
     
     expect(calculateTotalPrice('USD', cartItemsWithDollarsAndCents)).toBe('$3.68');
@@ -27,25 +27,21 @@ describe('calculateTotalPrice', () => {
   
   it('handles different currencies', () => {
     const cartItems = [
-      { price: 100, currency: 'GBP' },
-      { price: 100, currency: 'GBP' }
-    ];
-    
-    // defaults to USD but finds GBP
-    expect(calculateTotalPrice('USD', cartItems)).toBe('£2.00');
-  });
-  
-  it('handles missing currencies', () => {
-    const cartItemsMissingAllCurrencies = [
       { price: 100 },
       { price: 100 }
     ];
-    const cartItemsMissingOneCurrency = [
+
+    expect(calculateTotalPrice('GBP', cartItems)).toBe('£2.00');
+    expect(calculateTotalPrice('EUR', cartItems)).toBe('€2.00');
+  });
+  
+  it('handles different item currencies', () => {
+    const cartItems = [
+      { price: 100, currency: 'EUR' },
       { price: 100, currency: 'GBP' },
       { price: 100 }
     ];
     
-    expect(calculateTotalPrice('USD', cartItemsMissingAllCurrencies)).toBe('$2.00');
-    expect(calculateTotalPrice('USD', cartItemsMissingOneCurrency)).toBe('£2.00');
+    expect(calculateTotalPrice('USD', cartItems)).toBe('$3.00');
   });
 });

--- a/src/util.test.js
+++ b/src/util.test.js
@@ -1,0 +1,51 @@
+import { calculateTotalPrice } from './util';
+
+describe('calculateTotalPrice', () => {
+  it('adds all the prices together', () => {
+    const cartItems = [
+      { price: 100, currency: 'USD' },
+      { price: 200, currency: 'USD' }
+    ];
+    
+    expect(calculateTotalPrice('USD', cartItems)).toBe('$3.00');
+  });
+  
+  it('handles cents', () => {
+    const cartItemsWithDollarsAndCents = [
+      { price: 23, currency: 'USD' },
+      { price: 345, currency: 'USD' }
+    ];
+    
+    const cartItemsWithOnlyCents = [
+      { price: 1, currency: 'USD' },
+      { price: 2, currency: 'USD' }
+    ];
+    
+    expect(calculateTotalPrice('USD', cartItemsWithDollarsAndCents)).toBe('$3.68');
+    expect(calculateTotalPrice('USD', cartItemsWithOnlyCents)).toBe('$0.03');
+  });
+  
+  it('handles different currencies', () => {
+    const cartItems = [
+      { price: 100, currency: 'GBP' },
+      { price: 100, currency: 'GBP' }
+    ];
+    
+    // defaults to USD but finds GBP
+    expect(calculateTotalPrice('USD', cartItems)).toBe('£2.00');
+  });
+  
+  it('handles missing currencies', () => {
+    const cartItemsMissingAllCurrencies = [
+      { price: 100 },
+      { price: 100 }
+    ];
+    const cartItemsMissingOneCurrency = [
+      { price: 100, currency: 'GBP' },
+      { price: 100 }
+    ];
+    
+    expect(calculateTotalPrice('USD', cartItemsMissingAllCurrencies)).toBe('$2.00');
+    expect(calculateTotalPrice('USD', cartItemsMissingOneCurrency)).toBe('£2.00');
+  });
+});


### PR DESCRIPTION
Built to solve "Total Price totals up all prices of all products properly" in #4
This PR extracts the logic of totalPrice to `util.js` allowing it to be tested separately from the rest of the hook logic.

### Changes made:

- refactored repeated setup for tests using `beforeEach`
- moved totaling and conversion logic to `util.js`
- handled when currency is undefined
- add tests for `calculateTotalPrice`:
 - adds all prices together
 - handles cents
 - handles different currencies
 - handles missing currencies


#### Other concerns

I do, however, have some concerns around the calculation of `totalPrice`. As I was looking at the code, I saw that you're inferring the *currency* based on the items inside the cart. This is fine unless it's possible that the items in the cart have different `currency` properties. That would cause the item in the cart to be improperly converted (1 to 1 instead of say 1 to 1.25 for GBP to USD). I don't have much experience with Stripe so this may just not be possible and therefore not an issue. If it is we can open up a new issue for that.

Let me know if I need to make any changes 👍 

 