### PR TITLE
Fix reduceItemByOne and its tests

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -48,10 +48,25 @@ const removeItem = (skuID, cartItems) => {
   return newCartItems;
 };
 
+/**
+ * Reduces the quantity
+ * @param skuID
+ * @param cartItems
+ * @returns {*}
+ */
 const reduceItemByOne = (skuID, cartItems) => {
-  const newCartItems = cartItems;
-  const indexToRemove = newCartItems.map((item) => item.sku).indexOf(skuID);
-  newCartItems.splice(indexToRemove, 1);
+  const newCartItems = [];
+  let removedItem = false;
+
+  for (const item of cartItems) {
+    if (!removedItem && item.sku === skuID) {
+      removedItem = true;
+      continue;
+    }
+
+    newCartItems.push(item);
+  }
+
   return newCartItems;
 };
 


### PR DESCRIPTION
This fixes #48 where `reduceItemByOne` doesn't cause a re-render. However, we should probably update our tests to take a more _"does this render to the screen correctly"_ instead of _"has this property been modified/replaced to the correct value."_

I haven't verified that his has fixed the issue, however, it should have, I'll check once I get the chance. In the meantime, what do y'all think the best way to rewrite the tests to ensure the correct rendering would be?